### PR TITLE
Deleting from category_group and setting auto_increment

### DIFF
--- a/pscleaner.php
+++ b/pscleaner.php
@@ -259,7 +259,7 @@ class PSCleaner extends Module
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category_lang` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category_shop` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
-		$db->execute('DELETE FROM `'._DB_PREFIX_.'category_group` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
+                $db->execute('DELETE FROM `'._DB_PREFIX_.'category_group` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
                 $db->execute('ALTER TABLE `'._DB_PREFIX_.'category` AUTO_INCREMENT = '. (1 + max(array_merge($id_home, $id_root))));
                 foreach (scandir(_PS_CAT_IMG_DIR_) as $dir) {
                     if (preg_match('/^[0-9]+(\-(.*))?\.jpg$/', $dir)) {

--- a/pscleaner.php
+++ b/pscleaner.php
@@ -259,6 +259,8 @@ class PSCleaner extends Module
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category_lang` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
                 $db->execute('DELETE FROM `'._DB_PREFIX_.'category_shop` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
+		$db->execute('DELETE FROM `'._DB_PREFIX_.'category_group` WHERE id_category NOT IN ('.implode(',', array_map('intval', $id_home)).', '.implode(',', array_map('intval', $id_root)).')');
+                $db->execute('ALTER TABLE `'._DB_PREFIX_.'category` AUTO_INCREMENT = '. (1 + max(array_merge($id_home, $id_root))));
                 foreach (scandir(_PS_CAT_IMG_DIR_) as $dir) {
                     if (preg_match('/^[0-9]+(\-(.*))?\.jpg$/', $dir)) {
                         unlink(_PS_CAT_IMG_DIR_.$dir);


### PR DESCRIPTION
When truncating the catalog, it could remove the categories deleted from the table category_group and set the auto_increment the max existing + 1.