### PR TITLE
Truncate the attribute table also

### DIFF
--- a/pscleaner.php
+++ b/pscleaner.php
@@ -725,6 +725,7 @@ class PSCleaner extends Module
             'product_attribute_image',
             'attribute_impact',
             'attribute_lang',
+            'attribute',
             'attribute_group',
             'attribute_group_lang',
             'attribute_group_shop',


### PR DESCRIPTION
Needs to truncate the attribute table also. If not, after creating new attribute groups after a "cleaning" the old values will show again.