### PR TITLE
remove attribute_impact declared twice

### DIFF
--- a/pscleaner.php
+++ b/pscleaner.php
@@ -678,7 +678,6 @@ class PSCleaner extends Module
             'customization',
             'customization_field',
             'supply_order_detail',
-            'attribute_impact',
             'product_attribute',
             'product_attribute_shop',
             'product_attribute_combination',


### PR DESCRIPTION
In the function getCatalogRelatedTables() the table attribute_impact is declared twice