### PR TITLE
Truncate also search related table "alias"

### DIFF
--- a/pscleaner.php
+++ b/pscleaner.php
@@ -695,6 +695,7 @@ class PSCleaner extends Module
             'pack',
             'search_index',
             'search_word',
+            'alias',
             'specific_price',
             'specific_price_priority',
             'specific_price_rule',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Truncate also search related table "alias" when cleaning catalog
| Type?         | improvement
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | The alias table must be truncated after cleaning the catalog

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
